### PR TITLE
Chg: PHP 7.2 support

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -30,7 +30,7 @@ use humhub\modules\email_whitelist\models\EmailWhitelist;
 use Yii;
 use yii\helpers\Url;
 
-class Events extends \yii\base\Object
+class Events extends \yii\base\BaseObject
 {
 
     /**


### PR DESCRIPTION
So that those that use PHP 7.2 can use this module, also supported in v1.3.1 of HumHub.

Fix: https://github.com/humhub/humhub/issues/3251